### PR TITLE
result-option-assignment.adoc: fix ERROR: level 0 sections can only be used when doctype is book

### DIFF
--- a/assignments/result-option-assignment.adoc
+++ b/assignments/result-option-assignment.adoc
@@ -21,8 +21,8 @@ The variants of the Result type are `Ok()` and `Err(e)`. It is used to handle er
 If an operation was successful, `Ok()` is returned. `Ok()` can be empty or have a
 return value. `Err(e)` contains an error message that can be printed.
 
-# `match`
-
+[TIP]
+====
 Both types can be used with the `match` keyword. The received value is matched on patterns, each leads to the execution of a different expression.
 
 ----
@@ -32,8 +32,9 @@ match VALUE {
     PATTERN => EXPRESSION,
 }
 ----
+====
 
-# Template
+== Template
 
 Clone the teaching material repository at https://github.com/ferrous-systems/teaching-material[github.com/ferrous-systems/teaching-material].
 


### PR DESCRIPTION
when building the assignments, I got the error:

```
asciidoctor: ERROR: result-option-assignment.adoc: line 24: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: result-option-assignment.adoc: line 36: level 0 sections can only be used when doctype is book
```
This PR fixes that and tidies up the formatting result as a consequence. Note that 'match' and 'Template' now have different levels– I did this because to me, the 'match' section contains a hint (optional) whereas the 'Template' section contains a prerequisite for completing the task (mandatory, i.e. on the same level as the tasks themselves).

note: applying this PR will still yield
```
WARNING: result-option-assignment.adoc: line 24: section title out of sequence: expected level 1, got level 2
```
but since 'match' is the heading for a hint, rather than a task, this is intentional.