### PR TITLE
index.adoc: fix links to assignments

### DIFF
--- a/presentations/index.adoc
+++ b/presentations/index.adoc
@@ -44,12 +44,12 @@
 
 .Assignments
 
-* link:./assignments/fizzbuzz.html[FizzBuzz]
-* link:./assignments/result-option-assignment.html[Files, match and Results]
-* link:./assignments/redisish.html[Redisish protocol parser]
-* link:./assignments/tcp-server.html[TCP server]
-* link:./assignments/tcp-client.html[TCP client]
-* link:./assignments/simple-chat.html[Simple Chat]
-* link:./assignments/connected-mailbox.html[Connected mailbox]
-* link:./assignments/multithreaded-mailbox.html[Multithreaded mailbox]
-* link:./assignments/calc.html[Calculator]
+* link:../assignments/fizzbuzz.html[FizzBuzz]
+* link:../assignments/result-option-assignment.html[Files, match and Results]
+* link:../assignments/redisish.html[Redisish protocol parser]
+* link:../assignments/tcp-server.html[TCP server]
+* link:../assignments/tcp-client.html[TCP client]
+* link:../assignments/simple-chat.html[Simple Chat]
+* link:../assignments/connected-mailbox.html[Connected mailbox]
+* link:../assignments/multithreaded-mailbox.html[Multithreaded mailbox]
+* link:../assignments/calc.html[Calculator]


### PR DESCRIPTION
The current `index.html` generated from `index.adoc` yields 404s when you click on the assignment links. This PR fixes that.