### PR TITLE
gitignore: ignore generated html files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle/
 target/
+*.html


### PR DESCRIPTION
add generated html files to `.gitignore` to make `git status` output less... overly verbose