### PR TITLE
little-helpers/slides.adoc: fix WARNING: [...] unterminated open block

### DIFF
--- a/presentations/little-helpers/slides.adoc
+++ b/presentations/little-helpers/slides.adoc
@@ -171,5 +171,3 @@ fn addtion_test() {
     assert_eq!(addition(1,2), 3);
 }
 ----
-
---

--- a/presentations/little-helpers/slides.adoc
+++ b/presentations/little-helpers/slides.adoc
@@ -111,7 +111,7 @@ fn main() {
 [.centered]
 == Use Strings
 
-In the beginning, habitually use `+String`.
+In the beginning, habitually use `String`.
 
 [source,rust]
 ----


### PR DESCRIPTION
Also fix "+slides" typo while we're at it :)