### PR TITLE
BUILD.adoc: add link to bundler dep

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -3,7 +3,7 @@
 
 We use https://asciidoctor.org[Asciidoctor] for slides and assignments.
 
-To compile `.adoc` to HTML, you need to have Ruby, [bundler](https://rubygems.org/gems/bundler) and Python2 (for syntax highlighting) installed:
+To compile `.adoc` to HTML, you need to have Ruby and [bundler](https://rubygems.org/gems/bundler):
 
 .Prerequisites
 [source]

--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -3,7 +3,7 @@
 
 We use https://asciidoctor.org[Asciidoctor] for slides and assignments.
 
-To compile `.adoc` to HTML, you need to have Ruby, bundle and Python2 (for syntax highlighting) installed:
+To compile `.adoc` to HTML, you need to have Ruby, [bundler](https://rubygems.org/gems/bundler) and Python2 (for syntax highlighting) installed:
 
 .Prerequisites
 [source]


### PR DESCRIPTION
As a non-rubyist, it wasn't clear to me right away that the `bundle` dependency was a gem, and since the original gem appears to be called bundler[1] it took me a bit of headscratching to figure out what I needed to install. To save the next non-rubyist some time, I opened this PR. :)

[1] https://rubygems.org/gems/bundle/versions/0.0.1