### PR TITLE
Revert "Merge pull request #9 from Lotterleben/fix_assignment_links"

### DIFF
--- a/presentations/index.adoc
+++ b/presentations/index.adoc
@@ -44,12 +44,12 @@
 
 .Assignments
 
-* link:../assignments/fizzbuzz.html[FizzBuzz]
-* link:../assignments/result-option-assignment.html[Files, match and Results]
-* link:../assignments/redisish.html[Redisish protocol parser]
-* link:../assignments/tcp-server.html[TCP server]
-* link:../assignments/tcp-client.html[TCP client]
-* link:../assignments/simple-chat.html[Simple Chat]
-* link:../assignments/connected-mailbox.html[Connected mailbox]
-* link:../assignments/multithreaded-mailbox.html[Multithreaded mailbox]
-* link:../assignments/calc.html[Calculator]
+* link:./assignments/fizzbuzz.html[FizzBuzz]
+* link:./assignments/result-option-assignment.html[Files, match and Results]
+* link:./assignments/redisish.html[Redisish protocol parser]
+* link:./assignments/tcp-server.html[TCP server]
+* link:./assignments/tcp-client.html[TCP client]
+* link:./assignments/simple-chat.html[Simple Chat]
+* link:./assignments/connected-mailbox.html[Connected mailbox]
+* link:./assignments/multithreaded-mailbox.html[Multithreaded mailbox]
+* link:./assignments/calc.html[Calculator]


### PR DESCRIPTION
This PR reverts commit 64debc7b113a8a3f7814cc01c2f42d9550659b95, reversing
changes made to bfe11322cddbd67eef14c412761a635f6be2d9c5.

Turns out the problem I was trying to solve was on my machine, as is demonstrated by the assignments links in https://ferrous-systems.github.io/teaching-material/index.html, which currently throw a 404. (I've tested this PR by building it on my computer using the rakefile like I should have in the first place, and it solves the problem for me)