### PR TITLE
Cargo chapter: fix typos

### DIFF
--- a/presentations/cargo/slides.adoc
+++ b/presentations/cargo/slides.adoc
@@ -99,7 +99,8 @@ For more details, check the http://doc.crates.io/manifest.html[docs]
 
 At the first build (or through `cargo update`), cargo calculates a version tree fulfilling the constraints stated in Cargo.toml. If successful, it will be saved in a Lockfile (Cargo.lock).
 
-The Lockfile should always be kept under version control for applications. For libraries, it can be checked in to provide a repeatable test environment.
+The Lockfile should always be kept under version control for applications.
+For libraries, it can be checked in to provide a repeatable test environment.
 
 == Dependencies in detail
 

--- a/presentations/cargo/slides.adoc
+++ b/presentations/cargo/slides.adoc
@@ -28,7 +28,9 @@ In addition, a cargo project can contain:
 
 ==  The Manifest
 
-The http://doc.crates.io/manifest.html[Cargo Manifest] is written using http://doc.crates.io/manifest.html[TOML]. It at least contains the name of the project.
+The http://doc.crates.io/manifest.html[Cargo Manifest] is written using http://doc.crates.io/manifest.html[TOML].
+
+It at least contains the name of the project.
 
 [source,toml]
 ----
@@ -58,7 +60,9 @@ The debug profile is default here.
 
 == `cargo test`
 
-`cargo test` runs all tests. You can provide a test name or module name to filter the test being run.
+`cargo test` runs all tests.
+
+You can provide a test name or module name to filter the test being run.
 
 Tests use the debug profile per default.
 
@@ -97,9 +101,12 @@ For more details, check the http://doc.crates.io/manifest.html[docs]
 
 == Version resolution
 
-At the first build (or through `cargo update`), cargo calculates a version tree fulfilling the constraints stated in Cargo.toml. If successful, it will be saved in a Lockfile (Cargo.lock).
+At the first build (or through `cargo update`), cargo calculates a version tree fulfilling the constraints stated in Cargo.toml.
+
+If successful, it will be saved in a Lockfile (Cargo.lock).
 
 The Lockfile should always be kept under version control for applications.
+
 For libraries, it can be checked in to provide a repeatable test environment.
 
 == Dependencies in detail
@@ -135,7 +142,9 @@ Dependencies outside of crates.io are forbidden if a library is to be published 
 
 == Local paths
 
-It is possible to temporarily replace libraries though local ones. For this, their path needs to be registered in `$PROJECT_PATH/.cargo/config`.
+It is possible to temporarily replace libraries with local ones.
+
+For this, their path needs to be registered in `$PROJECT_PATH/.cargo/config`.
 
 [source,toml]
 ----
@@ -146,7 +155,9 @@ Libraries found here will be preferred. This allows easy testing of patches.
 
 == Profiles
 
-The cargo profiles (release, bench, test...) can be customized. Details can be found in the http://doc.crates.io/manifest.html[Manifest-documentation].
+The cargo profiles (release, bench, test...) can be customized.
+
+Details can be found in the http://doc.crates.io/manifest.html[Manifest-documentation].
 
 == Targets
 
@@ -157,13 +168,17 @@ The cargo profiles (release, bench, test...) can be customized. Details can be f
 
 == Workspaces
 
-Cargo can group multiple projects in a workspace. They then share settings and the same `target` directory.
+Cargo can group multiple projects in a workspace.
+
+They then share settings and the same `target` directory.
 
 See the http://doc.crates.io/manifest.html[manifest documentation] for details.
 
 == Features
 
-`rustc` provides the ability to ignore certain code parts on compilation. This happens through feature flags.
+`rustc` provides the ability to ignore certain code parts on compilation.
+
+This happens through feature flags.
 
 [source,rust]
 ----

--- a/presentations/cargo/slides.adoc
+++ b/presentations/cargo/slides.adoc
@@ -52,7 +52,7 @@ By default, cargo uses the Debug profile, which means that the resulting binary 
 
 If the project contains an application, you can run it using `+cargo run -- [Arguments]+`.
 
-If it contains multiple, the name of the intended binary can be given using `+--bin <name>+`.
+If it contains multiple binaries, the name of the intended binary can be given using `+--bin <name>+`.
 
 The debug profile is default here.
 
@@ -60,7 +60,7 @@ The debug profile is default here.
 
 `cargo test` runs all tests. You can provide a test name or module name to filter the test being run.
 
-Test use the debug profile per default.
+Tests use the debug profile per default.
 
 `cargo test --all --examples` runs all tests, including documentation test and compilation of examples!
 
@@ -86,7 +86,7 @@ If the version of a library is below `1`, it is considered "pre-release", which 
 
 == Version expressions
 
-Cargo allow expressing version ranges in different fashions.
+Cargo allows expressing version ranges in different fashions.
 
 - `=1.2.3`: Exact version, cargo will only use that one
 - `0.1`: Any patch version of the "0.1" series
@@ -99,7 +99,7 @@ For more details, check the http://doc.crates.io/manifest.html[docs]
 
 At the first build (or through `cargo update`), cargo calculates a version tree fulfilling the constraints stated in Cargo.toml. If successful, it will be saved in a Lockfile (Cargo.lock).
 
-The Lockfile should always be kept under version control for applications, for libraries, it can be checked in to provide a repeatable test environment.
+The Lockfile should always be kept under version control for applications. For libraries, it can be checked in to provide a repeatable test environment.
 
 == Dependencies in detail
 
@@ -134,7 +134,7 @@ Dependencies outside of crates.io are forbidden if a library is to be published 
 
 == Local paths
 
-It is possible to temporarily replace libraries though local ones. For this, their path need to be registered in `$PROJECT_PATH/.cargo/config`.
+It is possible to temporarily replace libraries though local ones. For this, their path needs to be registered in `$PROJECT_PATH/.cargo/config`.
 
 [source,toml]
 ----

--- a/presentations/index.adoc
+++ b/presentations/index.adoc
@@ -23,7 +23,6 @@
 * link:./stack-and-heap.html[Stack and Heap]
 * link:./error-handling.html[Error Handling]
 * link:./testing.html[Testing]
-* link:./cargo.html[Cargo]
 * link:./generics-basics.html[Basic Generics]
 
 .Advanced


### PR DESCRIPTION
fix typos, split some sentences into two to make them easier to read and remove duplicate link to the cargo chapter from the index.