### PR TITLE
Presentations: fix typos

### DIFF
--- a/presentations/crates/slides.adoc
+++ b/presentations/crates/slides.adoc
@@ -49,7 +49,7 @@ Crates can be renamed, just like normal use statements:
 include::./3.rs[]
 ----
 
-Note the `crate` keyword before it's usage. You're using a local alias. The original still exists.
+Note the `crate` keyword before its usage. You're using a local alias. The original still exists.
 
 == !
 

--- a/presentations/dynamic-dispatch/slides.adoc
+++ b/presentations/dynamic-dispatch/slides.adoc
@@ -40,7 +40,7 @@ Trait objects are a pair of pointers to a virtual function table and the data.
 - You can only use one trait per object
 - This trait must fulfill certain conditions
 
-== Rules for object-safe traits (abbrevated)
+== Rules for object-safe traits (abbreviated)
 
 - Object-safe traits are *not* allowed to require `Self: Sized`
 - All methods are object-safe

--- a/presentations/inner-mutability/slides.adoc
+++ b/presentations/inner-mutability/slides.adoc
@@ -23,14 +23,14 @@ We have some posts which have immutable content, and an incrementing view count.
 
 Ideally, we would have a `fn view(&self) -> &'static str` to return the content, and increment the view count.
 
-== Without `Cell`s
+== Without `Cell` s
 
 [source,rust]
 ----
 include::./1.rs[]
 ----
 
-== Without `Cell`s
+== Without `Cell` s
 
 This isn't ideal! `view` takes a `&mut self`, meaning this won't work:
 
@@ -39,7 +39,7 @@ This isn't ideal! `view` takes a `&mut self`, meaning this won't work:
 include::./2.rs[]
 ----
 
-== Without `Cell`s
+== Without `Cell` s
 
 [source,rust]
 ----

--- a/presentations/std-lib-tour/slides.adoc
+++ b/presentations/std-lib-tour/slides.adoc
@@ -60,7 +60,7 @@ include::./3.rs[]
 
 https://doc.rust-lang.org/std/sync/[`std::sync`]
 
-Provides types such a `Mutex`, `RwLock`, `CondVar`, `Arc` and `Barrier`s.
+Provides types such a `Mutex`, `RwLock`, `CondVar`, `Arc` and `Barrier` s.
 
 [source,rust]
 ----
@@ -72,6 +72,7 @@ include::./4.rs[]
 https://doc.rust-lang.org/std/io/trait.Read.html[`std::io::Read`] & https://doc.rust-lang.org/std/io/trait.Write.html[`std::io::Write`]
 
 Generic read and write functionality to files, sockets, buffers, and anything in between.
+
 Also part of https://doc.rust-lang.org/std/io/prelude/[`std::io::prelude`] (`use std::io::prelude::*`).
 
 [source,rust]

--- a/presentations/std-lib-tour/slides.adoc
+++ b/presentations/std-lib-tour/slides.adoc
@@ -15,7 +15,7 @@ https://doc.rust-lang.org/std/collections/index.html[`std::collections`]
 Contains a number of valuable data structures. In particular:
 
 * https://doc.rust-lang.org/std/vec/struct.Vec.html[`Vec`] for storing sequences of values.
-* https://doc.rust-lang.org/std/collections/struct.HashMap.html[`HashMap`] for storing as key value pairs.
+* https://doc.rust-lang.org/std/collections/struct.HashMap.html[`HashMap`] for storing key value pairs.
 
 When seeking to optimize code other options may be appropriate.
 
@@ -34,7 +34,9 @@ include::./1.rs[]
 
 https://doc.rust-lang.org/std/marker/struct.PhantomData.html[`std::marker::PhantomData`]
 
-Zero-sized type used to mark things that "act like" they own a `T`. These are useful for types which require markers, generics, or use unsafe code.
+Zero-sized types are used to mark things that "act like" they own a `T`.
+
+These are useful for types which require markers, generics, or use unsafe code.
 
 [source,rust]
 ----
@@ -45,14 +47,16 @@ include::./2.rs[]
 
 https://doc.rust-lang.org/std/process/struct.Command.html[`std::process::Command`]
 
-A process builder, providing fine-grained control over how a new process should be spawned. Used for interacting with other executables.
+A process builder, providing fine-grained control over how a new process should be spawned.
+
+Used for interacting with other executables.
 
 [source,rust]
 ----
 include::./3.rs[]
 ----
 
-== Syncronization Primitives
+== Synchronization Primitives
 
 https://doc.rust-lang.org/std/sync/[`std::sync`]
 


### PR DESCRIPTION
fix typos and formatting hickups in various Advanced presentations.