### PR TITLE
Fix runnability of rustplayground example

### DIFF
--- a/presentations/ownership/1.rs
+++ b/presentations/ownership/1.rs
@@ -5,11 +5,11 @@ struct Dot {
 }
 
 fn main() {
-    let dot = Dot { x: 1, y: 2 }; <1>
+    let dot = Dot { x: 1, y: 2 }; // <1>
     pacman(dot);
 }
 
-fn pacman(dot: Dot) { <2>
+fn pacman(dot: Dot) { // <2>
     println!("Eating {:?}", dot);
-    <3>
+    // <3>
 }

--- a/presentations/ownership/2.rs
+++ b/presentations/ownership/2.rs
@@ -7,7 +7,7 @@ struct Dot {
 fn main() {
     let dot = Dot { x: 1, y: 2 };
     pacman(dot);
-    pacman(dot); <1>
+    pacman(dot); // <1>
 }
 
 fn pacman(dot: Dot) {


### PR DESCRIPTION
Just saw today, that code does not compile in playground due to `<1>` nice bullet point.

[plaground link generated](https://play.rust-lang.org/?version=stable&code=%23%5Bderive(Debug)%5D%0Astruct%20Dot%20%7B%0A%20%20%20%20x%3A%20i32%2C%0A%20%20%20%20y%3A%20i32%0A%7D%0A%0Afn%20main()%20%7B%0A%20%20%20%20let%20dot%20%3D%20Dot%20%7B%20x%3A%201%2C%20y%3A%202%20%7D%3B%20(1)%0A%20%20%20%20pacman(dot)%3B%0A%7D%0A%0Afn%20pacman(dot%3A%20Dot)%20%7B%20(2)%0A%20%20%20%20println!(%22Eating%20%7B%3A%3F%7D%22%2C%20dot)%3B%0A%20%20%20%20(3)%0A%7D)