### PR TITLE
use ? instead of unwrap in ownership/5.rs

### DIFF
--- a/presentations/ownership/5.rs
+++ b/presentations/ownership/5.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
-fn main() {
-    let file = File::open("test").unwrap();
+fn main() -> io::Result<()> {
+    let file = File::open("test")?;
 
     use_file(file);
 }


### PR DESCRIPTION
Hello, just a little contribution to suggest using ? instead of raw unwrap it's a little bit early since ownership happens before control-flow. I can understand a rejection. :)

But as a teacher and trainer I found that introducing `unwrap` early is somewhat a curse because peoples get stuck with. :(

And as a programmer It took a long time before embracing a correct mindset with using `Result` gracefully, because I always looked into the `expect()`/`unwrap()` escape hatch.