### PR TITLE
remove callouts in playground; spelling

### DIFF
--- a/presentations/docinfo-footer.html
+++ b/presentations/docinfo-footer.html
@@ -11,9 +11,10 @@
             $(block).parent().prepend(buttons);
         });
         $('.open-in-playground').click(function () {
-            const code = $(this).siblings('code').text();
+            const code = $(this).siblings('code')[0].cloneNode(true);
+            for (const callout of code.getElementsByClassName("conum")) { callout.nextSibling.remove(); }
             const baseUrl = 'https://play.rust-lang.org/?version=stable&code=';
-            const payload = encodeURIComponent(code);
+            const payload = encodeURIComponent(code.innerText);
             const url = baseUrl + payload;
             window.open(url, '_blank');
         });

--- a/presentations/drop-panic-abort/2.rs
+++ b/presentations/drop-panic-abort/2.rs
@@ -1,7 +1,7 @@
 fn main() {
-    panicing_function();
+    panicking_function();
 }
 
-fn panicing_function() {
+fn panicking_function() {
     panic!("gosh, don't call me!");
 }


### PR DESCRIPTION
- when clicking `RUN`, the playground used to contain the `(1)`, `(2)` etc callouts as code. Not anymore.
- corrected the spelling of "panicking"