### PR TITLE
unconfuse remark about *Str and *String

### DIFF
--- a/presentations/strings/slides.adoc
+++ b/presentations/strings/slides.adoc
@@ -53,7 +53,7 @@ This is because `String` s implement `Deref<Target=str>` .
 
 -   `CStr` and `CString` may show up when working with FFI.
 
-The differences between `*Str` and `*String` are generally the same as the normal types.
+The differences between `[Os|C]Str` and `[Os|C]String` are generally the same as the normal types.
 
 == `OsString` & `OsStr`
 


### PR DESCRIPTION
Having the `*` as a wildcard there is a bit confusing as it could also be a dereference or raw pointer. This PR tries to resolve this by using different syntax. open to alternative suggestions.