### PR TITLE
Update compiler warning for unused Result

### DIFF
--- a/presentations/error-handling/2.output
+++ b/presentations/error-handling/2.output
@@ -1,5 +1,8 @@
-warning: unused variable: `outcome`, #[warn(unused_variables)] on by default
-  --> <anon>:10:9
+warning: unused `Result` that must be used
+  --> src/main.rs:10:5
    |
-10 |     let outcome = this_can_fail(true);
-   |         ^^^^^^^
+10 |     this_can_fail(true);
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_must_use)]` on by default
+   = note: this `Result` may be an `Err` variant, which should be handled

--- a/presentations/error-handling/2.rs
+++ b/presentations/error-handling/2.rs
@@ -1,0 +1,11 @@
+fn this_can_fail(succeeds: bool) -> Result<String, String> {
+    if succeeds {
+        Ok(String::from("Success"))
+    } else {
+        Err(String::from("Error"))
+    }
+}
+
+fn main() {
+    this_can_fail(true);
+}

--- a/presentations/error-handling/slides.adoc
+++ b/presentations/error-handling/slides.adoc
@@ -20,6 +20,11 @@ include::./1.rs[]
 
 == Results Must Be Used
 
+[source,rust]
+----
+include::./2.rs[]
+----
+
 [source]
 ----
 include::./2.output[]


### PR DESCRIPTION
Before the change the compiler displayed a warning of an unused variable. To make the distinction clearer that the `Result` return type has to be used, the slide is expanded with sample code that outputs the more specific warning.

This changes the warning from:

```
warning: unused variable: `outcome`, #[warn(unused_variables)] on by default
  --> <anon>:10:9
   |
10 |     let outcome = this_can_fail(true);
   |         ^^^^^^^
```

to

```
warning: unused `Result` that must be used
  --> src/main.rs:10:5
   |
10 |     this_can_fail(true);
   |     ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled
```