### PR TITLE
Set language of code blocks to Rust

### DIFF
--- a/assignments/simple-chat.adoc
+++ b/assignments/simple-chat.adoc
@@ -12,7 +12,7 @@ Note: this is a trimmed down version of the tutorial found in the https://book.a
 
 == 1. Clone the template
 
-[source,rust]
+[source,shell]
 ----
 $ git clone git@github.com:skade/async-chat-template.git
 ----
@@ -34,13 +34,13 @@ Implement the client function so that it:
 
 Go step by step, first reading the name from the input, printing it using `println` and then going from there.
 
-= Help
+== Help
 
-== Clone everywhere
+=== Clone everywhere
 
 This is an unoptimised example and moves `String` around everywhere. `clone` liberally, optimisations can come later.
 
-== Iterating over incoming lines
+=== Iterating over incoming lines
 
 [source,rust]
 ----

--- a/assignments/terrarium-serde.adoc
+++ b/assignments/terrarium-serde.adoc
@@ -29,12 +29,12 @@ You will learn:
 }
 ----
 3. Validate the JSON structure to have all those fields
-4. On success, return the structure with a 200 OK
-5. On error, return status 422, along with the resulting error
+4. On success, return the structure with a `200 OK`
+5. On error, return status `422`, along with the resulting error
 
 == Extension Task
 
-6. Make it optional to send the Address
+1. Make it optional to send the Address
 
 == Helpers
 
@@ -51,7 +51,7 @@ curl -XPOST --data-binary @my_json_file.json $URL
 
 Use https://serde.rs[SerDe]:
 
-[source,sh]
+[source,rust]
 ----
 extern crate serde;
 
@@ -62,14 +62,14 @@ extern crate serde_json;
 
 SerDe JSON allows either deserializing into a generic JSON value:
 
-[source,sh]
+[source,rust]
 ----
 let parsed_person = serde_json::from_slice::<serde_json::Value>(req.body());
 ----
 
 Or you can define a structure to be serializable and deserializable:
 
-[source,sh]
+[source,rust]
 ----
 #[derive(Serialize,Deserialize)]
 struct MyType {


### PR DESCRIPTION
A few minor adjustments to the assignments. The `assignments/terrarium-serde.adoc` assignment is not linked in the index.

* fix asciidoc warning, there can only be a single top level section (`=`)
* set appropriate language of source blocks in assignment