### PR TITLE
Refactor example break loop using label

### DIFF
--- a/presentations/control-flow/11a.rs
+++ b/presentations/control-flow/11a.rs
@@ -1,9 +1,13 @@
-'outer: for i in 0..10 {
-    loop {
-        if i < 5 {
-            continue 'outer;
-        } else {
-            break 'outer;
+fn main() {
+    'outer: for i in 0..10 {
+        for j in 0..5 {
+            if i + j > 10 {
+                break 'outer;
+            }
+            if j % 2 == 1 {
+                continue;
+            }
+            println!("Sum: {}+{}={}", i, j, i + j);
         }
     }
 }


### PR DESCRIPTION
The new example uses a slightly different control flow to print something to `stdout`. The inner loop also displays typical control flow using `continue` to skip iterations, while the `break` moves control to outer loop.