### PR TITLE
Add async imports to example

### DIFF
--- a/presentations/async-building-blocks/slides.adoc
+++ b/presentations/async-building-blocks/slides.adoc
@@ -50,6 +50,9 @@ fn read_from_disk(path: &str) -> std::io::Result<()> {
 
 [source,rust]
 ----
+use async_std::fs::File;
+use async_std::prelude::*;
+
 async fn read_from_disk(path: &str) -> std::io::Result<String> {
     let mut file = File::open(path).await?;
 


### PR DESCRIPTION
Add imports to show difference with previous slides. The code is basically the same but the example uses `async::fs::File` instead of `std::fs::File` for example.