### PR TITLE
Replace older async runtimes

### DIFF
--- a/presentations/async-building-blocks/slides.adoc
+++ b/presentations/async-building-blocks/slides.adoc
@@ -207,8 +207,7 @@ fn main() {
 
 * async_std
 * tokio
-* smol
-* nuclei
+* embassy (embedded)
 
 == Streams
 


### PR DESCRIPTION
Update async runtimes slide

* add `embassy` as embedded async runtime
* remove `smol` and `nuclei`