### PR TITLE
Partially revert "remove `extern crate`"

### DIFF
--- a/presentations/crates/0.rs
+++ b/presentations/crates/0.rs
@@ -1,3 +1,5 @@
+extern crate serde_json;
+
 fn main() {
     use serde_json::Value;
 


### PR DESCRIPTION
This partially reverts commit d1a639ff3d2dedaf6795f99cf70972eecafc4768.

The `crates/0.rs` snippet is specifically linked to Rust 2015, where `extern crate` was still required.