### PR TITLE
presentations/macros: Adjust `write!()` signature

### DIFF
--- a/presentations/macros/slides.adoc
+++ b/presentations/macros/slides.adoc
@@ -11,7 +11,7 @@ Rust has a macro language. See https://danielkeep.github.io/tlborm/book/README.h
 
 -   `println!(pattern, [values])` Easy printing of formatted strings to stdout
 -   `format!(pattern, [values])` like `println!`, but returns Strings
--   `write!(buf, pattern, string)` Simple writing of formatted data to a buffer
+-   `write!(buf, pattern, [values])` Simple writing of formatted data to a buffer
 
 == What Can They do?
 


### PR DESCRIPTION
`write!()` accepts 0..n value arguments, just like the other two highlighted macros.