### PR TITLE
presentations/macros: Fix typo

### DIFF
--- a/presentations/macros/slides.adoc
+++ b/presentations/macros/slides.adoc
@@ -34,7 +34,7 @@ Macros are:
 A macro has three parts.
 
 * A name, eg. `println`.
-* A input portion, defining that the macro accepts.
+* A input portion, defining what the macro accepts.
 * An output portion, defining how it expands.
 
 == Macros: Syntax


### PR DESCRIPTION
I assume "defining what the macro accepts" was the intended content of that sentence 😅 