### PR TITLE
The emoji example didn't compile because of a hidden character.

### DIFF
--- a/presentations/basic-types/6.rs
+++ b/presentations/basic-types/6.rs
@@ -2,6 +2,6 @@ fn main() {
     let ascii_char = 'r';
     let special_char = 'μ';
     let accented_char = 'Ŕ';
-    let emoji_char = '☢️';
+    let emoji_char = '☢';
     let seven_chars_emoji = '👨‍👩‍👧‍👧'; // Error: char must be one codepoint long
 }

--- a/presentations/basic-types/6.rs
+++ b/presentations/basic-types/6.rs
@@ -6,7 +6,7 @@ fn main() {
     // U+0154 LATIN CAPITAL LETTER R WITH ACUTE
     let accented_char = 'Ŕ';
     // U+2622 RADIOACTIVE SIGN
-    let emoji_char = '☢';
+    let emoji_char = '\u{2622}';
     // U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467
     let seven_chars_emoji = '👨‍👩‍👧‍👧'; // Error: char must be one codepoint long
 }

--- a/presentations/basic-types/6.rs
+++ b/presentations/basic-types/6.rs
@@ -1,7 +1,12 @@
 fn main() {
+    // U+0072 LATIN SMALL LETTER R
     let ascii_char = 'r';
+    // U+03BC GREEK SMALL LETTER MU
     let special_char = 'μ';
+    // U+0154 LATIN CAPITAL LETTER R WITH ACUTE
     let accented_char = 'Ŕ';
+    // U+2622 RADIOACTIVE SIGN
     let emoji_char = '☢';
+    // U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467
     let seven_chars_emoji = '👨‍👩‍👧‍👧'; // Error: char must be one codepoint long
 }


### PR DESCRIPTION
The editor used to create the file inserted an unprintable extra Unicode Scalar Value - U+FEOF. This is a 'Variation Selector' and it tells the UI to render the previous Code Point as an 'emoji' as opposed to rendering it as 'text'. Unfortunately, this meant the single-quote marks contained two Unicode Scalar Values instead of one, and we consequently got an error from rustc.

This change removes the U+FEOF. The emoji looks rubbish in comparison, but the code does not compile. Or at least, it fails where the comments say it should fail, as opposed to failing earlier on.

See https://unicode-table.com/en/FE0F/