### PR TITLE
Fix: history of rust

### DIFF
--- a/presentations/overview/slides.adoc
+++ b/presentations/overview/slides.adoc
@@ -18,7 +18,7 @@ include::./1.rs[]
 
 == A Little Bit of History
 
-- Rust is roughly 10 years old
+- Rust began around 2008
 - An experimental project by Graydon Hoare
 - Adopted by Mozilla
 - Presented to the general public as version 0.4 in 2012


### PR DESCRIPTION
this change avoids having to keep changing the slide that says
rust is about 10 years old.  instead we say that rust began around
2008.