### PR TITLE
Misc improvements 

### DIFF
--- a/assignments/connected-mailbox.adoc
+++ b/assignments/connected-mailbox.adoc
@@ -47,7 +47,7 @@ Implement `std::error::Error` for all your error types and start passing around 
 
 == Note
 
-To send and receive messages, you can either use `nc` or `telnet`. Alternatively, you can use the client provided: https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/tcp-client
+To send and receive messages, you can either use `nc` or `telnet`. Alternatively, you can use the client provided: https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/tcp-client
 
 Usage:
 

--- a/assignments/multithreaded-mailbox.adoc
+++ b/assignments/multithreaded-mailbox.adoc
@@ -24,12 +24,12 @@ For every connection:
 
 === Base code
 
-If you want to start from a clean state, you can use the solution code from the last exercise: https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/tcp-client
+If you want to start from a clean state, you can use the solution code from the last exercise: https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/tcp-client
 
 
 === `tcp-client`
 
-To send and receive messages, you can either use `nc` or `telnet`. Alternatively, you can use the client provided: https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/tcp-client
+To send and receive messages, you can either use `nc` or `telnet`. Alternatively, you can use the client provided: https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/tcp-client
 
 Usage:
 

--- a/assignments/redis-protobuf.adoc
+++ b/assignments/redis-protobuf.adoc
@@ -12,7 +12,7 @@ Step 1::
 
 * Install the https://grpc.io/docs/protoc-installation/[protoc compiler] (required by `prost-build`).
 * Create a binary project called `redis-client-protobuf`: `cargo new --bin redis-client-protobuf` and add your redis client library as a path dependency.
-* Copy the https://github.com/ferrous-systems/teaching-material/tree/master/assignments/redis-protobuf[protobuf definitions] to your source directory.
+* Copy the https://github.com/ferrous-systems/teaching-material/tree/main/assignments/redis-protobuf[protobuf definitions] to your source directory.
 
 == Implementation
 Step 2::

--- a/assignments/redis.adoc
+++ b/assignments/redis.adoc
@@ -47,4 +47,4 @@ Hook up your command line arguments to the `RedisClient`. In the `get` case, `pr
 
 == Solution
 
-https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/redis
+https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/redis

--- a/assignments/semver_from_file.adoc
+++ b/assignments/semver_from_file.adoc
@@ -38,6 +38,6 @@ match VALUE {
 
 Clone the teaching material repository at https://github.com/ferrous-systems/teaching-material[github.com/ferrous-systems/teaching-material].
 
-A template with example data can be found in folder https://github.com/ferrous-systems/teaching-material/tree/master/assignments/semver/parse_file/template[assignments/semver/parse_file/template]. It already imports (`use` s) all required items.
+A template with example data can be found in folder https://github.com/ferrous-systems/teaching-material/tree/main/assignments/semver/parse_file/template[assignments/semver/parse_file/template]. It already imports (`use` s) all required items.
 
 == Task: see template for details

--- a/assignments/semver_server.adoc
+++ b/assignments/semver_server.adoc
@@ -13,7 +13,7 @@ You will learn:
 == Task
 
 1. Move all your previous work on `SemVer` into a `lib.rs` module
-2. Create a skeleton TCP server based on https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/tcp-echo-server
+2. Create a skeleton TCP server based on https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/tcp-echo-server
 3. Deserialize incoming crates based on the following protocol:
     - `GET <crate_name>\n`
     - `PUT <crate_data_without_newlines>\n`
@@ -25,7 +25,7 @@ You will learn:
 
 == Note
 
-To send and receive messages, you can either use `nc` or `telnet`. Alternatively, you can use the client provided: https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/tcp-client
+To send and receive messages, you can either use `nc` or `telnet`. Alternatively, you can use the client provided: https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/tcp-client
 
 The entire source tree can be found here:
 [source]

--- a/fill_in_the_blanks/closures.adoc
+++ b/fill_in_the_blanks/closures.adoc
@@ -99,5 +99,5 @@ fn main(){
 
 Distribute the code snippet below in a https://play.rust-lang.org[playground]
 
-You can find an example solution in https://github.com/ferrous-systems/teaching-material/tree/master/assignments/solutions/fill_in_the_blanks[teaching-material/assignments/solutions/fill_in_the_blanks].
+You can find an example solution in https://github.com/ferrous-systems/teaching-material/tree/main/assignments/solutions/fill_in_the_blanks[teaching-material/assignments/solutions/fill_in_the_blanks].
 It is called `closures.rs`. You can run it by calling `cargo run --bin closures` in the `fill_in_the_blanks` directory.

--- a/presentations/crates/0.rs
+++ b/presentations/crates/0.rs
@@ -1,8 +1,8 @@
 extern crate serde_json;
 
-fn main() {
-    use serde_json::Value;
+use serde_json::Value;
 
+fn main() {
     let data = r#" { "name": "John Doe", "age": 43, ... } "#;
     let v: Value = serde_json::from_str(data)?;
     println!(

--- a/presentations/crates/1.rs
+++ b/presentations/crates/1.rs
@@ -1,6 +1,6 @@
-fn main() {
-    use serde_json::{self, Value};
+use serde_json::{self, Value};
 
+fn main() {
     let data = r#" { "name": "John Doe", "age": 43, ... } "#;
     let v: Value = serde_json::from_str(data)?;
     println!(

--- a/presentations/crates/slides.adoc
+++ b/presentations/crates/slides.adoc
@@ -19,7 +19,7 @@ This imports the "SERialisation/DEserialisation"-Framework.
 
 == !
 
-In Rust 2018 this is no longer required.
+Rust 2018 onwards this is no longer required.
 Libraries that were declared via cargo can simply be used with `use`-statements.
 
 [source,rust]

--- a/presentations/installation/slides.adoc
+++ b/presentations/installation/slides.adoc
@@ -87,6 +87,12 @@ For details, check the http://doc.crates.io/manifest.html[Cargo Manifest docs].
 * rust-analyzer: https://rust-analyzer.github.io
 * IntelliJ Rust plugin for their IDEs (CLion, Idea, etc.): https://www.jetbrains.com/rust/
 
+== rust-analyzer: Things to know
+
+* With VSCode you need this extension - https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer
+* You must remove the default (now deprecated) Rust extension if you have that installed
+* rust-analyzer helps you have those IDE-like features
+
 == Add some tooling
 
 [source,sh]

--- a/presentations/iterators/slides.adoc
+++ b/presentations/iterators/slides.adoc
@@ -96,15 +96,3 @@ Filter out unwanted values, skipping further computation on them:
 ----
 include::./6.rs[]
 ----
-
-== Laziness
-
-Iterators are applied lazily, so the process is efficient:
-
-
-|===
-|Step | [0] | [1] | [2] | [3]
-| | 1 | 2 | 3 | 4
-|filter(\|x\| x % 2 == 0) | | 2 | | 4
-|map(\|x\| x * 2) | | 4 | | 8
-|===

--- a/presentations/strings/1.rs
+++ b/presentations/strings/1.rs
@@ -1,5 +1,5 @@
 fn main() {
-    // &'static str
+    // &str
     let this = "Hallo";
     // String
     let that: String = String::from("Hallo");

--- a/presentations/strings/slides.adoc
+++ b/presentations/strings/slides.adoc
@@ -33,8 +33,6 @@ include::./1.rs[]
 
 -   `String` is the *easiest* to use when starting out. Refine later.
 -   `String` owns its data, so works well as a field of a `struct` or Enum.
-
--   `&'static str` works well for constant values.
 -   `&str` is typically used in function arguments.
 
 == `Deref` Coercion


### PR DESCRIPTION
- changes the `master` to `main` in some links
- moves `use` statements outside of `fn main()` in some cases
- better wording for intro of Rust timeline
- r-a related documentation and links
- removes hard to read slide about iterators laziness
- removes mention of `'static` in the intro to strings slides because it is too early to introduce that concept

cc/ @listochkin @jntrnr 