### PR TITLE
editorconfig for rudimentary automatic formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+[*.{rs, toml}]
+indent_size = 4
+
+[*.rb, Gemfile]
+indent_size = 2
+
+[*.{js, json, .css}]
+indent_size = 2
+
+[*.{yaml, yml}]
+indent_size = 2
+
+[*.sh]
+indent_style = tab


### PR DESCRIPTION
It needs a plugin for your editor, but you likely have one installed already.

I thought of adding automatic formatters for JS, Ruby, Rust, Shell, etc. but:
 1. that's a lot of work for not much benefit
 2. Would slow down builds considerably
 3. Might not work for Rust because many code snippets aren't complete programs anyway
