### PR TITLE
semantic highlighting for unsafe blocks in VSCode

### DIFF
--- a/presentations/unsafe/slides.adoc
+++ b/presentations/unsafe/slides.adoc
@@ -66,3 +66,13 @@ As Rust forbids aliasing, it is impossible in safe Rust to split a slice into 2 
 ----
 include::./2.rs[]
 ----
+
+== Highlight unsafe code in VSCode
+
+* Will highlight which function calls are `unsafe` inside an `unsafe` block
+* Helpful for longer `unsafe` blocks
+
+[source,json]
+----
+include::./vscode-settings.json[]
+----

--- a/presentations/unsafe/vscode-settings.json
+++ b/presentations/unsafe/vscode-settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.semanticTokenColorCustomizations": {
+        "rules": {
+            "*.unsafe:rust": "#ff00ff"
+        }
+    }
+}


### PR DESCRIPTION
We show it during trainings anyway, but it's nice to have it in slides, and not as a piece of tribal knowledge.